### PR TITLE
add convenience functions

### DIFF
--- a/easy.js
+++ b/easy.js
@@ -1,0 +1,22 @@
+var FreeStyle = require('./dist/free-style')
+
+var globalSheet
+
+exports.style = function(object) {
+  requestInject()
+  return globalSheet.registerStyle(object)
+}
+
+exports.rule = function(query, object) {
+  requestInject()
+  return globalSheet.registerRule(query, object)
+}
+
+var requestInject = function() {
+  if (globalSheet) return
+  globalSheet = FreeStyle.create()
+  requestAnimationFrame(function() {
+    globalSheet.inject()
+    globalSheet = null
+  })
+}


### PR DESCRIPTION
This seems like a pretty decent way for most libraries to use free-style but if your not sure I'm happy publish it as a separate module. You use this like:

```js
import {style} from 'free-style/easy'

const hover = style({
	background: 'blue'
})

<div class={hover}/>
```

And it automatically injects the generated CSS in batches asynchronously. Since most packages define everything in the first event loop of the app running you will end up with just one `style` node being injected for you whole app