### PR TITLE
Avoids sorting nested style rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/blakeembrey/free-style",
   "devDependencies": {
-    "blue-tape": "^0.1.10",
-    "istanbul": "^0.3.6",
+    "blue-tape": "^0.2.0",
+    "istanbul": "^0.4.2",
     "just-css-properties": "^1.0.0",
     "pre-commit": "^1.0.6",
     "tap-spec": "^4.1.1",
     "typescript": "^1.7.5",
-    "typings": "^0.3.5"
+    "typings": "^0.6.8"
   }
 }

--- a/src/free-style.spec.ts
+++ b/src/free-style.spec.ts
@@ -392,4 +392,22 @@ test('free style', (t) => {
       t.end()
     })
   })
+
+  t.test('keep order of nested params', t => {
+    const Style = create()
+
+    const className = Style.registerStyle({
+      width: '20rem',
+      '@media screen and (min-width: 500px)': {
+        width: 500
+      },
+      '@media screen and (min-width: 1000px)': {
+        width: 1000
+      }
+    })
+
+    t.equal(Style.getStyles(), `.${className}{width:20rem}@media screen and (min-width: 500px){.${className}{width:500px}}@media screen and (min-width: 1000px){.${className}{width:1000px}}`)
+
+    t.end()
+  })
 })

--- a/src/free-style.ts
+++ b/src/free-style.ts
@@ -156,7 +156,7 @@ function sortTuples <T> (value: T[]): T[] {
 /**
  * Categorize user styles.
  */
-function parseUserStyles (styles: UserStyles) {
+function parseUserStyles (styles: UserStyles, hasNestedStyles: boolean) {
   const properties: Properties = []
   const nestedStyles: NestedStyles = []
 
@@ -173,7 +173,7 @@ function parseUserStyles (styles: UserStyles) {
 
   return {
     properties: sortTuples(properties),
-    nestedStyles: sortTuples(nestedStyles)
+    nestedStyles: hasNestedStyles ? nestedStyles : sortTuples(nestedStyles)
   }
 }
 
@@ -198,13 +198,13 @@ function interpolate (selector: string, parent: string) {
 /**
  * Register all styles, but collect for post-selector correction using the hash.
  */
-function collectHashedStyles (container: Cache<any>, styles: UserStyles, shouldInterpolate: boolean) {
+function collectHashedStyles (container: Cache<any>, styles: UserStyles, hasNestedStyles: boolean) {
   const instances: [string, Style][] = []
 
   let currentHash = 0
 
   function stylize (container: Cache<any>, styles: UserStyles, selector: string) {
-    const { properties, nestedStyles } = parseUserStyles(styles)
+    const { properties, nestedStyles } = parseUserStyles(styles, hasNestedStyles)
     const styleString = stringifyProperties(properties)
     const style = container.add(new Style(styleString))
 
@@ -217,7 +217,7 @@ function collectHashedStyles (container: Cache<any>, styles: UserStyles, shouldI
       if (isAtRule(name)) {
         stylize(container.add(new Rule(name)), value, selector)
       } else {
-        stylize(container, value, shouldInterpolate ? interpolate(name, selector) : name)
+        stylize(container, value, hasNestedStyles ? interpolate(name, selector) : name)
       }
     }
   }
@@ -248,7 +248,7 @@ function registerUserStyles (container: FreeStyle | Rule, styles: UserStyles): s
  */
 function registerUserRule (container: FreeStyle | Rule, selector: string, styles: UserStyles): void {
   const instances: [string, Style][] = []
-  const { properties, nestedStyles } = parseUserStyles(styles)
+  const { properties, nestedStyles } = parseUserStyles(styles, false)
   const styleString = stringifyProperties(properties)
   const rule = container.add(new Rule(selector, styleString))
 


### PR DESCRIPTION
Closes https://github.com/blakeembrey/free-style/issues/19. It's a small tweak to skip sorting the tuples when parsing for nested styles (but not nested rules).