### PR TITLE
Fix "process is not defined" using rollup

### DIFF
--- a/src/free-style.ts
+++ b/src/free-style.ts
@@ -484,6 +484,6 @@ export class FreeStyle extends Cache<Rule | Style> implements Container<FreeStyl
 /**
  * Exports a simple function to create a new instance.
  */
-export function create (hash = stringHash, debug = process.env['NODE_ENV'] !== 'production') {
+export function create (hash = stringHash, debug = typeof process !== 'undefined' && process.env['NODE_ENV'] !== 'production') {
   return new FreeStyle(hash, debug)
 }


### PR DESCRIPTION
When using free-style with rollup (and probably other bundlers that doesn't expose a process object) it fails with "process is not defined". Check first to see if process is undefined to make sure free-style works out of the box with those bundlers.