### PR TITLE
add insertion based sorting for overloaded keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -926,15 +926,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string.prototype.trim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
@@ -944,6 +935,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.1",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/src/free-style.spec.ts
+++ b/src/free-style.spec.ts
@@ -197,6 +197,19 @@ test('free style', (t) => {
     t.end()
   })
 
+  t.test('overloaded keys should sort in insertion order', t => {
+    const Style = create()
+
+    // At least with V8 ~6.0, sorting more than 10 items will result in equal items being out of insertion order
+    const className = Style.registerStyle({
+      foo: [15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2 ]
+    })
+
+    t.equal(Style.getStyles(), `.${className}{foo:15px;foo:13px;foo:11px;foo:9px;foo:7px;foo:5px;foo:3px;foo:1px;foo:14px;foo:12px;foo:10px;foo:8px;foo:6px;foo:4px;foo:2px}`)
+
+    t.end()
+  })
+
   t.test('merge duplicate nested styles', t => {
     const Style = create()
 

--- a/src/free-style.ts
+++ b/src/free-style.ts
@@ -119,7 +119,13 @@ function styleToString (key: string, value: string | number | boolean) {
  * Sort an array of tuples by first value.
  */
 function sortTuples <T extends any[]> (value: T[]): T[] {
-  return value.sort((a, b) => a[0] > b[0] ? 1 : -1)
+  return value.sort((a, b) => {
+    if (a[0] === b[0]) {
+      return a[2] > b[2] ? 1 : -1
+    } else {
+      return a[0] > b[0] ? 1 : -1
+    }
+  })
 }
 
 /**
@@ -142,7 +148,7 @@ function parseStyles (styles: Styles, hasNestedStyles: boolean) {
           const prop = hyphenate(key.trim())
 
           for (let i = 0; i < value.length; i++) {
-            properties.push([prop, value[i]])
+            properties.push([prop, value[i], i])
           }
         } else {
           nestedStyles.push([key.trim(), value])


### PR DESCRIPTION
The current sort is unstable. Using V8 ~6.0, sorting more than 10 style keys results in insertion order for overloads not being respected. The consequences of this, other than rendering overloads out of order, create a particularly insidious bug when server-side rendering. Because the string is different, the hash will be different when we render on a Node server and try to hydrate on something like Firefox, where the sort is still technically unstable, but acts differently than V8. If you are trying to hydrate with something like React, it will complain that the client side generated code doesn't match the server output.

To see an example, add the test to the current branch and watch the output (running Node 8.x, although I don't know how far back it goes). Keep in mind, this isn't just for overrides that go beyond 10 elements, as every other style joins the sort as well. I noticed it using typestyle's csstips module for flexbox which does 3 display overrides, but will render them out of insertion order when you add 8+ extra styles on top of that.