### PR TITLE
Styles that fire together wire together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
     on_failure: change
 
 node_js:
-  - '4'
+  - '6'
   - stable
 
 after_script:

--- a/benchmarks/perf.ts
+++ b/benchmarks/perf.ts
@@ -4,7 +4,7 @@ const cssProperties = require('just-css-properties')
 
 const Style = create()
 const start = process.hrtime()
-const count = Math.pow(10, 4.5)
+const count = Math.pow(10, 5)
 
 for (let i = 0; i < count; i += 3) {
   const p1 = cssProperties[(i + 1) % cssProperties.length]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "lint": "tslint \"src/**/*.ts\"",
+    "lint": "tslint \"src/**/*.ts\" --project tsconfig.json",
     "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
     "bench:hash": "ts-node benchmarks/hash.ts",
     "bench:perf": "ts-node benchmarks/perf.ts",

--- a/src/free-style.ts
+++ b/src/free-style.ts
@@ -323,11 +323,6 @@ export class Cache <T extends Container<any>> {
         this.changeId++
         this.changes.change(item, curIndex, curIndex)
       }
-    } else {
-      // Check if contents are different.
-      if (item.getStyles() !== style.getStyles()) {
-        throw new TypeError(`Hash collision: ${style.getStyles()} === ${item.getStyles()}`)
-      }
     }
 
     return item


### PR DESCRIPTION
Refactors styles to keep singularly registered styles together and avoids de-duping across style registrations. This will help consistency of projects and avoids needing to do style re-ordering.

Related to https://github.com/blakeembrey/free-style/issues/41 and maintains https://github.com/blakeembrey/free-style/issues/14.