### PR TITLE
Add module entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Make CSS easier and more maintainable by using JavaScript",
   "main": "dist/free-style.js",
   "typings": "dist/free-style.d.ts",
+  "module": "dist.es2015/free-style.js",
   "jsnext:main": "dist.es2015/free-style.js",
   "files": [
     "dist/",


### PR DESCRIPTION
This is the default entry for rollup which doesn't resolve `jsnext:main`. Would be a nice to have so that it works right away on rollup.