### PR TITLE
Add support for child pseudo classes to parent selector lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "1.6 kB"
+      "limit": "1.61 kB"
     }
   ],
   "jest": {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -480,6 +480,37 @@ describe("free style", () => {
     expect(Style.getStyles()).toEqual("body{height:100%}body a{color:red}");
   });
 
+  it("should add pseudo class to each selector in a selector list (no whitespace)", () => {
+    const Style = create();
+
+    const className = Style.registerStyle({
+      "& > input,& .foo > input": {
+        "&:focus": { background: "green" },
+      },
+    });
+
+    expect(Style.getStyles()).toEqual(
+      `.${className} > input:focus, .${className} .foo > input:focus{background:green}`
+    );
+  });
+
+  it("should add pseudo class to each selector in a selector list (whitespace)", () => {
+    const Style = create();
+
+    const className = Style.registerStyle({
+      "& > input, & .foo > input": {
+        "&:focus": { background: "green" },
+      },
+      "& > button,   & .foo > button": {
+        "&:first": { background: "green" },
+      },
+    });
+
+    expect(Style.getStyles()).toEqual(
+      `.${className} > input:focus, .${className} .foo > input:focus,.${className} > button:first, .${className} .foo > button:first{background:green}`
+    );
+  });
+
   it("should interpolate recursively with a rule", () => {
     const Style = create();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,10 @@ function escape(str: string) {
  * Interpolate the `&` with style name.
  */
 function interpolate(selector: string, styleName: string) {
-  return selector.replace(/&/g, styleName);
+  return styleName
+    .split(/, */)
+    .map((x) => selector.replace(/&/g, x))
+    .join(", ");
 }
 
 /**


### PR DESCRIPTION
Here's one possible fix for #103. Suggestions or other fixes very welcome. I haven't done heavy testing/benchmarking with this code yet but I wanted to start a discussion here.

Some questions I had:

* Are there other CSS selectors that contain commas where this will break or become troublesome?
* This fix ignores the amount of whitespace in between selectors in a selector list and always outputs `, ` as a delimiter -- does that matter?

Closes #103